### PR TITLE
Race conditon in SFListeners.kt

### DIFF
--- a/src/main/kotlin/pl/kacperduras/skinfetcher/SFListeners.kt
+++ b/src/main/kotlin/pl/kacperduras/skinfetcher/SFListeners.kt
@@ -39,6 +39,8 @@ class SFListeners(private val plugin: SFPlugin): Listener {
 
     val uuid = this.plugin.executor.getUUID(connection.name) ?: return
 
+    event.registerIntent(this.plugin)
+    
     this.plugin.proxy.scheduler.runAsync(this.plugin, {
       try {
         val call: Call<JsonObject> = this.service.profile(SFPlugin.SESSION_URL.format(uuid.trim()))
@@ -70,8 +72,6 @@ class SFListeners(private val plugin: SFPlugin): Listener {
         event.completeIntent(this.plugin)
       }
     })
-
-    event.registerIntent(this.plugin)
   }
 
   private fun InitialHandler.inject(profile: LoginResult) {


### PR DESCRIPTION
Log:
```
15:51:28 [SEVERE] Task BungeeTask(sched=net.md_5.bungee.scheduler.BungeeScheduler@479cbee5, id=0, owner=pl.kacperduras.skinfetcher.SFPlugin@4d6025c5, task=pl.kacperduras.skinfetcher.api.APIExecutor@59e2d8e3, delay=1000, period=1000, running=true) encountered an exception
java.lang.IllegalStateException: Plugin pl.kacperduras.skinfetcher.SFPlugin@4d6025c5 has not registered intent for event PreLoginEvent
at com.google.common.base.Preconditions.checkState(Preconditions.java:721)
at net.md_5.bungee.api.event.AsyncEvent.completeIntent(AsyncEvent.java:68)
at pl.kacperduras.skinfetcher.api.APIExecutor.run(APIExecutor.kt:43)
at net.md_5.bungee.scheduler.BungeeTask.run(BungeeTask.java:63)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
at java.lang.Thread.run(Thread.java:748)
```